### PR TITLE
Fix --with/--without args of build system

### DIFF
--- a/config/pipeline.m4
+++ b/config/pipeline.m4
@@ -1,46 +1,8 @@
-AC_MSG_CHECKING(whether to build pipeline library)
-AC_ARG_WITH([pipeline],
-	AS_HELP_STRING([--without-pipeline], [Disable pipeline library compilation [default=no]]),
-without_pipeline="yes", [])
+#ROFL pipeline
 
-if test "$without_pipeline" = "yes"; then
-	if test "$without_cplusplus" = "yes"; then
-		#Compile nothing???
-		AC_MSG_ERROR(Invalid combination of flags --without-cplusplus and --without-pipeline)
-	fi
-	PIPELINE_SUPPORT="no"
-else
-	PIPELINE_SUPPORT="yes"
-fi
+AC_SUBST([ROFL_PIPELINE_PRESENT], ["#define ROFL_PIPELINE_PRESENT 1"])
 
-#Fancy message
-AC_MSG_RESULT($PIPELINE_SUPPORT)
-
-AM_CONDITIONAL(PIPELINE_SUPPORT, test $PIPELINE_SUPPORT = yes)
-AM_COND_IF([PIPELINE_SUPPORT],[
-	AC_SUBST([ROFL_PIPELINE_PRESENT], ["#define ROFL_PIPELINE_PRESENT 1"])
-	AC_CONFIG_FILES([
-	src/rofl/datapath/pipeline/Makefile
-	src/rofl/datapath/pipeline/common/Makefile
-	src/rofl/datapath/pipeline/platform/Makefile
-	src/rofl/datapath/pipeline/openflow/Makefile
-	src/rofl/datapath/pipeline/openflow/openflow1x/Makefile
-	src/rofl/datapath/pipeline/openflow/openflow1x/pipeline/Makefile
-	src/rofl/datapath/pipeline/openflow/openflow1x/pipeline/matching_algorithms/Makefile
-	src/rofl/datapath/pipeline/util/Makefile
-
-	test/rofl/datapath/pipeline/openflow/openflow1x/pipeline/Makefile
-	test/rofl/datapath/pipeline/monitoring/Makefile
-	test/rofl/datapath/pipeline/openflow/openflow1x/pipeline/bufs/Makefile
-	test/rofl/datapath/pipeline/openflow/openflow1x/pipeline/ma/Makefile
-	test/rofl/datapath/pipeline/openflow/openflow1x/pipeline/ma/loop/Makefile
-	test/rofl/datapath/pipeline/openflow/openflow1x/pipeline/ma/l2hash/Makefile
-	test/rofl/datapath/pipeline/openflow/openflow1x/pipeline/static/Makefile
-	test/rofl/datapath/pipeline/openflow/openflow1x/pipeline/reset_pipeline/Makefile
-])])
-#	test/rofl/datapath/pipeline/openflow/openflow1x/pipeline/dynamic/Makefile
-
-## pipeline
+## Matching algorithms
 MATCHING_ALGORITHMS_DIR="src/rofl/datapath/pipeline/openflow/openflow1x/pipeline/matching_algorithms"
 AC_SUBST(MATCHING_ALGORITHMS_DIR)
 MATCHING_ALGORITHMS="loop l2hash"

--- a/config/pipeline_opts.m4
+++ b/config/pipeline_opts.m4
@@ -6,70 +6,63 @@
 ##
 ##
 #if test "$PIPELINE_SUPPORT" = "yes"; then
-AM_COND_IF([PIPELINE_SUPPORT],[
-	CFLAGS+=" -D__COMPILING_ROFL_PIPELINE__"
-	CXXFLAGS+=" -D__COMPILING_ROFL_PIPELINE__"
+CFLAGS+=" -D__COMPILING_ROFL_PIPELINE__"
+CXXFLAGS+=" -D__COMPILING_ROFL_PIPELINE__"
 
-	AC_MSG_CHECKING(whether to inline platform functions in ROFL-pipeline packet processing API)
-enable_inline="no"
+AC_ARG_WITH([pipeline-platform-funcs-inlined], AS_HELP_STRING([--with-pipeline-platform-funcs-inlined], [Inline platform functions in ROFL-pipeline packet processing API [default=no]]))
 
-	#Detect option
-	AC_ARG_WITH([pipeline-platform-funcs-inlined], AS_HELP_STRING([--with-pipeline-platform-funcs-inlined], [Inline platform functions in ROFL-pipeline packet processing API [default=no]]), with_pipeline_inline="yes", [])
+AC_MSG_CHECKING(whether to inline platform functions in ROFL-pipeline packet processing API)
+AS_IF([test "x$with_pipeline_platform_funcs_inlined" == xyes],[
+	AC_SUBST([ROFL_PIPELINE_INLINE_PP_PLATFORM_FUNCS], ["#define ROFL_PIPELINE_INLINE_PP_PLATFORM_FUNCS 1"])
+	AC_SUBST([ROFL_PIPELINE_ABORT_IF_INLINED], ["
+#ifdef ROFL_PIPELINE_ABORT_IF_INLINED
+	#error rofl-pipeline has been compiled with packet processing API functions inlined, but target does not support it(ROFL_PIPELINE_ABORT_IF_INLINED). Please recompile rofl-datapath without --with-pipeline-platform-funcs-inlined
+#endif"])
+	AC_MSG_RESULT(yes)
+])
+AS_IF([test "x$with_pipeline_platform_funcs_inlined" != xyes],[
+	AC_MSG_RESULT(no)
+])
 
-	if test "$with_pipeline_inline" = "yes"; then
-	
-		AC_SUBST([ROFL_PIPELINE_INLINE_PP_PLATFORM_FUNCS], ["#define ROFL_PIPELINE_INLINE_PP_PLATFORM_FUNCS 1"])
-		
-		AC_SUBST([ROFL_PIPELINE_ABORT_IF_INLINED], ["#ifdef ROFL_PIPELINE_ABORT_IF_INLINED
-	#error rofl-pipeline has been compiled with packet processing API functions inlined, but target does not support it(ROFL_PIPELINE_ABORT_IF_INLINED). Please recompile rofl-core without --with-pipeline-platform-funcs-inlined
-#endif]")
-		AC_MSG_RESULT(yes)
+#Pipeline thread IDs
+AC_MSG_CHECKING(the maximum number of threads/cpus for ROFL-pipeline packet processing API) 
+AC_ARG_WITH([pipeline-max-tids], AS_HELP_STRING([--with-pipeline-max-tids=num], [maximum number of threads/cpus that ROFL-pipeline packet processing API supports concurrently without locking. Supported values {2,4,8,16,32,64} [default=16]]), with_pipeline_max_tids=yes, [])
+
+#Default value	
+MAX_TIDS=16
+
+#TODO: There is probably a better way to do this and that is still portable
+if test "$with_pipeline_max_tids" = "yes"; then
+	if test "$withval" = "2"; then
+		MAX_TIDS=$withval
+	elif test "$withval" = "4"; then
+		MAX_TIDS=$withval
+	elif test "$withval" = "8"; then
+		MAX_TIDS=$withval
+	elif test "$withval" = "16"; then
+		MAX_TIDS=$withval
+	elif test "$withval" = "32"; then
+		MAX_TIDS=$withval
+	elif test "$withval" = "64"; then
+		MAX_TIDS=$withval
 	else
-		AC_MSG_RESULT(no)
-	fi
+		AC_MSG_RESULT(ERROR)
+		AC_ERROR([Invalid value for --with-pipeline-max-tids of '$withval'; supported values {2,4,8,16,32,64}])
+	fi	
+fi
+AC_MSG_RESULT($MAX_TIDS)
 
-	#Pipeline thread IDs
-	AC_MSG_CHECKING(the maximum number of threads/cpus for ROFL-pipeline packet processing API) 
-	AC_ARG_WITH([pipeline-max-tids], AS_HELP_STRING([--with-pipeline-max-tids=num], [maximum number of threads/cpus that ROFL-pipeline packet processing API supports concurrently without locking. Supported values {2,4,8,16,32,64} [default=16]]), with_pipeline_max_tids=yes, [])
+AC_SUBST([ROFL_PIPELINE_MAX_TIDS], ["#define ROFL_PIPELINE_MAX_TIDS $MAX_TIDS"])
+AC_SUBST([ROFL_PIPELINE_LOCKED_TID], ["#define ROFL_PIPELINE_LOCKED_TID 0"])
 
-	#Default value	
-	MAX_TIDS=16
 
-	#TODO: There is probably a better way to do this and that is still portable
-	if test "$with_pipeline_max_tids" = "yes"; then
-		if test "$withval" = "2"; then
-			MAX_TIDS=$withval
-		elif test "$withval" = "4"; then
-			MAX_TIDS=$withval
-		elif test "$withval" = "8"; then
-			MAX_TIDS=$withval
-		elif test "$withval" = "16"; then
-			MAX_TIDS=$withval
-		elif test "$withval" = "32"; then
-			MAX_TIDS=$withval
-		elif test "$withval" = "64"; then
-			MAX_TIDS=$withval
-		else
-			AC_MSG_RESULT(ERROR)
-		  	AC_ERROR([Invalid value for --with-pipeline-max-tids of '$withval'; supported values {2,4,8,16,32,64}])
-		fi	
-	fi
-	AC_MSG_RESULT($MAX_TIDS)
-
-	AC_SUBST([ROFL_PIPELINE_MAX_TIDS], ["#define ROFL_PIPELINE_MAX_TIDS $MAX_TIDS"])
-	AC_SUBST([ROFL_PIPELINE_LOCKED_TID], ["#define ROFL_PIPELINE_LOCKED_TID 0"])
-	
-	
-	#Pipeline lockless
-	AC_MSG_CHECKING(whether to compile ROFL-pipeline packet processing API without locking) 
-	AC_ARG_WITH([pipeline-lockless], AS_HELP_STRING([--with-pipeline-lockless], [compiles ROFL-pipeline packet processing API without locking [default=no]]), with_pipeline_lockless="yes", [])
-
-		
-	if test "$with_pipeline_lockless" = "yes"; then
-		AC_SUBST([ROFL_PIPELINE_LOCKLESS], ["#define ROFL_PIPELINE_LOCKLESS 1"])
-		AC_MSG_RESULT(yes)
-	else
-		AC_SUBST([ROFL_PIPELINE_LOCKLESS], [""])
-		AC_MSG_RESULT(no)
-	fi
+#Pipeline lockless
+AC_ARG_WITH([pipeline-lockless], AS_HELP_STRING([--with-pipeline-lockless], [compiles ROFL-pipeline packet processing API without locking [default=no]]))
+AC_MSG_CHECKING(whether to compile ROFL-pipeline packet processing API without locking)
+AS_IF([test "x$with_pipeline_lockless" == xyes],[
+	AC_SUBST([ROFL_PIPELINE_LOCKLESS], ["#define ROFL_PIPELINE_LOCKLESS 1"])
+	AC_MSG_RESULT(yes)
+])
+AS_IF([test "x$with_pipeline_lockless" != xyes], [
+	AC_MSG_RESULT(no)
 ])

--- a/configure.ac
+++ b/configure.ac
@@ -64,6 +64,24 @@ AC_CONFIG_FILES([
 	src/rofl/datapath/hal/openflow/openflow1x/Makefile
 	src/rofl/datapath/hal/extensions/Makefile
 
+	src/rofl/datapath/pipeline/Makefile
+	src/rofl/datapath/pipeline/common/Makefile
+	src/rofl/datapath/pipeline/platform/Makefile
+	src/rofl/datapath/pipeline/openflow/Makefile
+	src/rofl/datapath/pipeline/openflow/openflow1x/Makefile
+	src/rofl/datapath/pipeline/openflow/openflow1x/pipeline/Makefile
+	src/rofl/datapath/pipeline/openflow/openflow1x/pipeline/matching_algorithms/Makefile
+	src/rofl/datapath/pipeline/util/Makefile
+
+	test/rofl/datapath/pipeline/openflow/openflow1x/pipeline/Makefile
+	test/rofl/datapath/pipeline/monitoring/Makefile
+	test/rofl/datapath/pipeline/openflow/openflow1x/pipeline/bufs/Makefile
+	test/rofl/datapath/pipeline/openflow/openflow1x/pipeline/ma/Makefile
+	test/rofl/datapath/pipeline/openflow/openflow1x/pipeline/ma/loop/Makefile
+	test/rofl/datapath/pipeline/openflow/openflow1x/pipeline/ma/l2hash/Makefile
+	test/rofl/datapath/pipeline/openflow/openflow1x/pipeline/static/Makefile
+	test/rofl/datapath/pipeline/openflow/openflow1x/pipeline/reset_pipeline/Makefile
+
 	test/Makefile
 
 	src/rofl_datapath_conf.h


### PR DESCRIPTION
The current config/pipeline_opts.m4 was not correctly capturing
explicit --without-pipeline-<feature> and was enabling them.

This patch fixes this issue. It also removes the useless
--with-pipeline switch.

Partially fixes bisdn/xdpd/#80 bisdn/xdpd/#81

@toanju or @vicalro can you please have a look to it?
