### PR TITLE
pipeline/logging: fix C++11 compilation

### DIFF
--- a/src/rofl/datapath/pipeline/util/logging.h
+++ b/src/rofl/datapath/pipeline/util/logging.h
@@ -57,14 +57,14 @@ extern int (*rofl_pipeline_debug_print)(FILE *stream, const char *format, ...);
 	#define ROFL_PIPELINE_DEBUG_PRINT(fd, cn, level, stuff, ...)  \
 	    do{\
 		if (ROFL_PIPELINE_DEBUG_CHECK(cn, level) && *rofl_pipeline_debug_print != NULL){ \
-			rofl_pipeline_debug_print(fd,"[rofl-pipeline] "stuff, ##__VA_ARGS__);\
+			rofl_pipeline_debug_print(fd, "[rofl-pipeline] " stuff, ##__VA_ARGS__);\
 		}\
 	    }while(0)
 
 	#define ROFL_PIPELINE_DEBUG_PRINT_NO_PREFIX(fd, cn, level, stuff, ...)  \
 	    do{\
 		if (ROFL_PIPELINE_DEBUG_CHECK(cn, level) && *rofl_pipeline_debug_print != NULL){ \
-			rofl_pipeline_debug_print(fd,stuff, ##__VA_ARGS__);\
+			rofl_pipeline_debug_print(fd, stuff, ##__VA_ARGS__);\
 		}\
 	    }while(0)
 


### PR DESCRIPTION
When compiled with C++11 the following warning that becomes an
on -Wall -Werror arises:

/rofl/datapath/pipeline/util/logging.h:60:33: error: unable to find string literal operator 'operator""stuff'
    rofl_pipeline_debug_print(fd,"[rofl-pipeline] "stuff, ##**VA_ARGS**);

(-Wreserved-user-defined-literal)

Fix it by adding extra whitespaces.
