### PR TITLE
pipeline: allow to match on cookie for flow_add

### DIFF
--- a/src/rofl/datapath/pipeline/openflow/openflow1x/pipeline/matching_algorithms/l2hash/of1x_l2hash_ma.c
+++ b/src/rofl/datapath/pipeline/openflow/openflow1x/pipeline/matching_algorithms/l2hash/of1x_l2hash_ma.c
@@ -258,7 +258,7 @@ void of1x_remove_hook_l2hash(of1x_flow_entry_t *const entry){
 
 
 /* Conveniently wraps call with mutex.  */
-rofl_of1x_fm_result_t of1x_add_flow_entry_l2hash(of1x_flow_table_t *const table, of1x_flow_entry_t *const entry, bool check_overlap, bool reset_counts){
+rofl_of1x_fm_result_t of1x_add_flow_entry_l2hash(of1x_flow_table_t *const table, of1x_flow_entry_t *const entry, bool check_overlap, bool reset_counts, bool check_cookie){
 
 	//Check if the flowmod is not empty, and return
 	//Note that this cannot be checked by the fast validation bitmap
@@ -266,7 +266,7 @@ rofl_of1x_fm_result_t of1x_add_flow_entry_l2hash(of1x_flow_table_t *const table,
 		return ROFL_OF1X_FM_FAILURE;
 
 	//Call loop with the right hooks
-	return __of1x_add_flow_entry_loop(table, entry, check_overlap, reset_counts, of1x_add_hook_l2hash);
+	return __of1x_add_flow_entry_loop(table, entry, check_overlap, reset_counts, check_cookie, of1x_add_hook_l2hash);
 }
 
 rofl_of1x_fm_result_t of1x_modify_flow_entry_l2hash(of1x_flow_table_t *const table, of1x_flow_entry_t *const entry, const enum of1x_flow_removal_strictness strict, bool reset_counts){

--- a/src/rofl/datapath/pipeline/openflow/openflow1x/pipeline/matching_algorithms/loop/of1x_loop_ma.h
+++ b/src/rofl/datapath/pipeline/openflow/openflow1x/pipeline/matching_algorithms/loop/of1x_loop_ma.h
@@ -8,9 +8,9 @@
 //C++ extern C
 ROFL_BEGIN_DECLS
 
-rofl_of1x_fm_result_t __of1x_add_flow_entry_loop(of1x_flow_table_t *const table, of1x_flow_entry_t *const entry, bool check_overlap, bool reset_counts, void (*ma_hook_ptr)(of1x_flow_entry_t*));
+rofl_of1x_fm_result_t __of1x_add_flow_entry_loop(of1x_flow_table_t *const table, of1x_flow_entry_t *const entry, bool check_overlap, bool reset_counts, bool check_cookie, void (*ma_hook_ptr)(of1x_flow_entry_t*));
 
-rofl_of1x_fm_result_t of1x_add_flow_entry_loop(of1x_flow_table_t *const table, of1x_flow_entry_t *const entry, bool check_overlap, bool reset_counts);
+rofl_of1x_fm_result_t of1x_add_flow_entry_loop(of1x_flow_table_t *const table, of1x_flow_entry_t *const entry, bool check_overlap, bool reset_counts, bool check_cookie);
 
 rofl_of1x_fm_result_t __of1x_modify_flow_entry_loop(of1x_flow_table_t *const table, of1x_flow_entry_t *const entry, const enum of1x_flow_removal_strictness strict, bool reset_counts, void (*ma_add_hook_ptr)(of1x_flow_entry_t*), void (*ma_modify_hook_ptr)(of1x_flow_entry_t*));
 

--- a/src/rofl/datapath/pipeline/openflow/openflow1x/pipeline/matching_algorithms/matching_algorithms.h
+++ b/src/rofl/datapath/pipeline/openflow/openflow1x/pipeline/matching_algorithms/matching_algorithms.h
@@ -101,7 +101,8 @@ typedef struct of1x_matching_algorithm_functions{
 	(*add_flow_entry_hook)(struct of1x_flow_table *const table,
 			of1x_flow_entry_t *const entry,
 			bool check_overlap,
-			bool reset_counts);
+			bool reset_counts,
+			bool check_cookie);
 
 
 	/**

--- a/src/rofl/datapath/pipeline/openflow/openflow1x/pipeline/matching_algorithms/trie/of1x_trie_ma.c
+++ b/src/rofl/datapath/pipeline/openflow/openflow1x/pipeline/matching_algorithms/trie/of1x_trie_ma.c
@@ -736,7 +736,8 @@ bool __of1x_prune_leafs_trie(of1x_flow_table_t *const table, of1x_trie_t* trie,
 rofl_of1x_fm_result_t of1x_add_flow_entry_trie(of1x_flow_table_t *const table,
 								of1x_flow_entry_t *const entry,
 								bool check_overlap,
-								bool reset_counts){
+								bool reset_counts,
+								bool check_cookie){
 	rofl_of1x_fm_result_t res = ROFL_OF1X_FM_SUCCESS;
 	of1x_trie_t* trie = (of1x_trie_t*)table->matching_aux[0];
 	struct of1x_trie_leaf *prev, *next;
@@ -822,7 +823,7 @@ rofl_of1x_fm_result_t of1x_add_flow_entry_trie(of1x_flow_table_t *const table,
 
 		if(curr_entry && __of1x_check_priority_cookie_trie(entry, curr_entry,
 										true,
-										false)){
+										check_cookie)){
 			ROFL_PIPELINE_DEBUG("[flowmod-modify(%p)][trie] Existing entry (%p) will be updated with (%p)\n", entry, curr_entry, entry);
 
 			//Head of the entry linked list
@@ -973,7 +974,7 @@ MODIFY_END:
 
 	//According to spec
 	if(moded == 0 && res == ROFL_OF1X_FM_SUCCESS)
-		res = of1x_add_flow_entry_trie(table, entry, false, reset_counts);
+		res = of1x_add_flow_entry_trie(table, entry, false, reset_counts, check_cookie);
 	else
 		of1x_destroy_flow_entry(entry);
 

--- a/src/rofl/datapath/pipeline/openflow/openflow1x/pipeline/of1x_flow_table.c
+++ b/src/rofl/datapath/pipeline/openflow/openflow1x/pipeline/of1x_flow_table.c
@@ -439,7 +439,7 @@ rofl_result_t __of1x_destroy_table(of1x_flow_table_t* table){
 * Specific matchings may point them to their own routines, but they MUST always call
 * of1x_[whatever]_flow_entry_table_imp in order to update the main tables
 */
-rofl_of1x_fm_result_t of1x_add_flow_entry_table(of1x_pipeline_t *const pipeline, const unsigned int table_id, of1x_flow_entry_t **const entry, bool check_overlap, bool reset_counts){
+rofl_of1x_fm_result_t __of1x_add_flow_entry_table(of1x_pipeline_t *const pipeline, const unsigned int table_id, of1x_flow_entry_t **const entry, bool check_overlap, bool reset_counts, bool check_cookie){
 
 	rofl_of1x_fm_result_t result;
 	of1x_flow_table_t* table;
@@ -471,7 +471,7 @@ rofl_of1x_fm_result_t of1x_add_flow_entry_table(of1x_pipeline_t *const pipeline,
 
 
 	//Perform insertion (node that in 1.0 operation ADD must always reset counters on overlap)
-	result = of1x_matching_algorithms[table->matching_algorithm].add_flow_entry_hook(table, *entry, check_overlap, reset_counts || ( pipeline->sw->of_ver == OF_VERSION_10 ));
+	result = of1x_matching_algorithms[table->matching_algorithm].add_flow_entry_hook(table, *entry, check_overlap, reset_counts || ( pipeline->sw->of_ver == OF_VERSION_10 ), check_cookie);
 
 	if(result != ROFL_OF1X_FM_SUCCESS){
 		//Release rdlock

--- a/src/rofl/datapath/pipeline/openflow/openflow1x/pipeline/of1x_flow_table.h
+++ b/src/rofl/datapath/pipeline/openflow/openflow1x/pipeline/of1x_flow_table.h
@@ -172,6 +172,29 @@ rofl_result_t __of1x_destroy_table(of1x_flow_table_t* table);
 */
 
 /**
+* @brief Add flow entry to table being able to match cookie
+* @warning As a rule of thumb use always of1x_add_flow_entry_table()
+*
+* OpenFlow spec treats ADD as ADD or MODIFY, even though MODIFY action also
+* exists (all versions). To make things even more bizzare, it strictly
+* forbbids to match on cookie for ADD, but allows the checking on MODIFY.
+*
+* __of1x_add_flow_entry_table() allows insertion of entries with the optional
+* cookie match flag. This can simplifying insertion of backup rules instead of
+* having them to treat them as ECMP always.
+*
+* When multiple entries with the same matches are inserted, only the highest
+* priority one will be matched. The rest will be inserted but not used, unless
+* higher priority rules are removed. If two or more entries have the same match
+* but different priority, matching is undefined (one of them will be match
+* only).
+*
+* @warning Some HW platforms may not support it in some/all tables.
+* @warning Out of OpenFlow spec.
+*/
+rofl_of1x_fm_result_t __of1x_add_flow_entry_table(struct of1x_pipeline *const pipeline, const unsigned int table_id, of1x_flow_entry_t **const entry, bool check_overlap, bool reset_counts, bool check_cookie);
+
+/**
 * @ingroup core_of1x 
 * Add a flow_entry to a table.
 *
@@ -196,7 +219,9 @@ rofl_result_t __of1x_destroy_table(of1x_flow_table_t* table);
 * @warning On success (ROFL_FM_SUCCESS), the entry pointer (*entry) will be set to NULL. 
 * or freed from outside the library.
 */
-rofl_of1x_fm_result_t of1x_add_flow_entry_table(struct of1x_pipeline *const pipeline, const unsigned int table_id, of1x_flow_entry_t **const entry, bool check_overlap, bool reset_counts);
+static inline rofl_of1x_fm_result_t of1x_add_flow_entry_table(struct of1x_pipeline *const pipeline, const unsigned int table_id, of1x_flow_entry_t **const entry, bool check_overlap, bool reset_counts){
+	return __of1x_add_flow_entry_table(pipeline, table_id, entry, check_overlap, reset_counts, false);
+}
 
 /**
 * @ingroup core_of1x 


### PR DESCRIPTION
OpenFlow spec (all versions) treats ADD as ADD or UPDATE,
even though MODIFY action also exists. To make things even more
bizzare, it strictly forbbids to match on cookie for ADD, but
allows the checking on MODIFY.

This is annoying, specially when simple control planes want to be
implemented (e.g. without explicit ECMP support via GROUPS).

This commit keeps the API of1x_add_flow_entry_table() as it was,
to keep backwards compatibility and be fully OF compliant, but it
opens a back-door, __of1x_add_flow_entry_table() to be able to
match in cookie _also_ during insertion.