### PR TITLE
toolchain: added AM_PROG_CC_C_O again

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -9,6 +9,7 @@ AC_GNU_SOURCE
 
 AC_PROG_INSTALL
 AC_PROG_CC
+AM_PROG_CC_C_O # this is still needed for rhel
 AC_PROG_LD
 m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])


### PR DESCRIPTION
rhel comes with automake 1.13 and autoconf 2.69 which do not yet
support the checks by running only AC_PROG_CC. Since AM_PROG_CC_C_O is
a no-op in a more modern automake this can be safely added.